### PR TITLE
annotate for many fields per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ The `scores` format is `path:name:column:op` where:
 + column indicates the column number (or INFO name) to pull from the scores VCF.
 + op is a `vcfanno` operation.
 
++ multiple annotations for the same file can be used as such:
+```
+python pathoscore.py annotate --prefix benign \
+ --scores score-sets/GRCh37/aloft/aloft.txt.gz:aloft_het,aloft_lof,aloft_rec:5,6,7:max,max,max \
+ truth-sets/GRCh37/clinvar/clinvar-benign.20170905.vcf.gz
+```
+
 ### exclude
 
 can be a population VCF that is used to filter would-be pathogenic variants (as we know that common variants can't be pathogenic). This can also be a set of regions to exclude, and for user convenience we curated gene sets that the user can filter on such as autosomal dominant genes from Berg et al. (2013) and haploinsufficient genes from Dang et al. (2008).

--- a/pathoscore.py
+++ b/pathoscore.py
@@ -587,21 +587,26 @@ def annotate(args):
 
     fh = open("%s.conf" % args.prefix, "w")
     lua_fields = ['"%s"' % i for i in infos(args.query_vcf)]
-    names = []
     for path, name, field, op in scores:
-        names.append(name)
+        fields = []
+        name = name.split(",")
+        op = op.split(",")
         lua_fields.append('"%s"' % name)
-        if not field.isdigit():
-            field = '"%s"' % field
-            col = "fields"
-        else:
-            col = "columns"
+        field = field.split(",")
+        for f in field:
+            if not f.isdigit():
+                f = '"%s"' % f
+                col = "fields"
+            else:
+                col = "columns"
+            fields.append(int(f))
         fh.write("""[[annotation]]
 file="{path}"
-names=["{name}"]
-{col}=[{field}]
-ops=["{op}"]
+names={name}
+{col}={fields}
+ops={op}
 \n""".format(**locals()))
+        print (name, op, fields, col)
 
     for exclude in (args.exclude or []):
         field = """fields=["AF"]""" if exclude.endswith(".vcf.gz") else """columns=[1]"""


### PR DESCRIPTION
annotate can now take a comma separated list of field names, column numbers and operations for each file for score sets with multiple scores:

for example from a folder in the main directory:

    python ../pathoscore.py annotate --scores ../score-sets/GRCh37/CCR/ccrs.autosomes.v2.20180420.bed.gz:CCR:4:max --scores ../score-sets/GRCh37/CCR/ccrs.xchrom.v2.20180420.bed.gz:CCR:4:max --scores ../score-sets/GRCh37/aloft/aloft.txt.gz:aloft_het,aloft_lof,aloft_rec:5,6,7:max,max,max --scores ../score-sets/GRCh37/fathmm/fathmm/fathmm.txt.gz:fathmm_non,fathmm_coding:5,6:max,max --scores ../score-sets/GRCh37/fitcons/fitcons/fitcons.bed.gz:fitCons:4:max ../truth-sets/GRCh37/clinvar/clinvar-benign.20170905.vcf.gz --prefix benign

this will make it so the user does not need to edit a conf file nor write the same file name many times.